### PR TITLE
_read_channel_raw fix, longint support

### DIFF
--- a/adafruit_hx711/hx711.py
+++ b/adafruit_hx711/hx711.py
@@ -122,8 +122,8 @@ class HX711:
             self._clock_pin.value = False
 
         # Convert to 32-bit signed integer
-        if value & 0x800000:
-            value |= 0xFF000000
+        if value & 0x80_00_00:
+            value -= 0x1_00_00_00
 
         return value
 


### PR DESCRIPTION
@ladyada 
Resolves: #2 

Discussed this change on discord with @jepler: https://discord.com/channels/327254708534116352/327298996332658690/1315814085803249724 

It seems the code using the longint wasn't correct for the given MIN and MAX values from the datasheet. The corrected code doesn't make use of longint.

I tested importing this modified library on a device without longint to confirm it no longer raises the overflow error. 

Sensor is otw and I will test initializing and reading data once it arrives. 