### PR TITLE
Revert longint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,8 @@ or individual libraries can be installed using
 
 `Purchase one from the Adafruit shop <http://www.adafruit.com/products/5974>`_
 
+This driver does not support MCU's without longint support.
+
 Installing from PyPI
 =====================
 

--- a/adafruit_hx711/hx711.py
+++ b/adafruit_hx711/hx711.py
@@ -123,7 +123,7 @@ class HX711:
 
         # Convert to 32-bit signed integer
         if value & 0x80_00_00:
-            value -= 0x1_00_00_00
+            value |= 0xFF_00_00_00
 
         return value
 


### PR DESCRIPTION
@ladyada 
Resolves: #4 

Reverting the change from #3. I think that I didn't have this wired up correctly when I tested the PR, or else the gauge I was trying to use is wrong or broken. 

I got a new https://www.adafruit.com/product/4541 and have set it up with the HX711 for testing today. This time around I do get values that differ from the the Arduino library. Right now I get 3 different values respectively from:
- Arduino library on a Metro 328
- CircuitPython with #3 change
- CircuitPython without #3 change

It's not clear to me which of those different values is the correct / expected one, I don't think I could get to the bottom it very quickly, so I've opted to revert the change from #3 for now. 

I found this code in the 3rd party driver which was linked in the original issue: https://github.com/fivesixzero/CircuitPython_HX711/blob/4efc13f5e69f482d9b43936077e19e5fbeb7f285/hx711/hx711_gpio.py#L72-L74 which is similar to the changes made in #3 but it uses greater than instead of `&` bitwise in the if statement. 

In the longer term perhaps it's worth comparing the implementation in this library with the one from https://github.com/fivesixzero/CircuitPython_HX711/tree/main to see what differences exist and determine if we can use the approach from that library if it does indeed allow for supporting non-long int builds. For me, this would require a deeper dive into the datasheet and perhaps the arduino library to try to understand which values are the expected ones. 