### PR TITLE
Add fast reading function and refactor read_channel methods for HX711

### DIFF
--- a/adafruit_hx711/hx711.py
+++ b/adafruit_hx711/hx711.py
@@ -39,9 +39,7 @@ __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/your-repo/Adafruit_CircuitPython_HX711.git"
 
 
-def read_fast(
-    clock_pin: digitalio.DigitalInOut, data_pin: digitalio.DigitalInOut, size: int
-):
+def read_fast(clock_pin: digitalio.DigitalInOut, data_pin: digitalio.DigitalInOut, size: int):
     value: int = 0  # return value
     assert not clock_pin.value
     assert size > 0
@@ -73,9 +71,7 @@ class HX711:
     CHAN_A_GAIN_64 = 27
     CHAN_B_GAIN_32 = 26
 
-    def __init__(
-        self, data_pin: digitalio.DigitalInOut, clock_pin: digitalio.DigitalInOut
-    ) -> None:
+    def __init__(self, data_pin: digitalio.DigitalInOut, clock_pin: digitalio.DigitalInOut) -> None:
         """
         Initialize the HX711 module.
 
@@ -121,9 +117,7 @@ class HX711:
         :return: ADC value.
         """
         return self._read_channel_raw(chan_gain) - (
-            self._tare_value_b
-            if chan_gain == self.CHAN_B_GAIN_32
-            else self._tare_value_a
+            self._tare_value_b if chan_gain == self.CHAN_B_GAIN_32 else self._tare_value_a
         )
 
     def _read_channel_raw(self, chan_gain: int) -> int:
@@ -137,9 +131,7 @@ class HX711:
             pass  # Wait until the HX711 is ready
 
         self._clock_pin.value = False
-        value = read_fast(self._clock_pin, self._data_pin, chan_gain) >> (
-            chan_gain - 24
-        )
+        value = read_fast(self._clock_pin, self._data_pin, chan_gain) >> (chan_gain - 24)
 
         # Convert to 32-bit signed integer
         if value & 0x80_00_00:


### PR DESCRIPTION
This pull request addresses the issue #7.

I made a separated function `read_fast` for the bit banging reading of the AD. This improved the performance by [caching the object reference](https://docs.micropython.org/en/latest/reference/speed_python.html#caching-object-references) and opens up possibilities for other implementations.

The delays are enforced with the `microcontroller.delay_us` function.

I had to disable the interrupts during the read, because according to the datasheet, the clock is not allowed to stay up for more than 50µs during the operation :

<img width="591" height="411" alt="image" src="https://github.com/user-attachments/assets/a7f07b56-fa21-4c52-9dcc-7a93fa86f655" />

With interrupts on, I was not able to guarantee the correct timing.

I tested on a ESP32 and it never failed.

Note that some other lines have been reformated according to the style guide defined in `ruff.toml` (`line-length = 100`)